### PR TITLE
Create a custom 404 error page

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { Icons } from "@repo/ui/icons";
+import { Button } from "@repo/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 space-y-6 text-center">
+      <Icons.HelpCircle className="h-16 w-16 text-muted-foreground" />
+      <h1 className="text-5xl font-bold tracking-tight">Page not found</h1>
+      <p className="max-w-md text-muted-foreground">
+        Sorry, the page you are looking for could not be found.
+      </p>
+      <Button asChild className="mt-4">
+        <Link href="/">Go back home</Link>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
Add a basic 404 Not Found page for the web app.

This page serves as a placeholder implementation to fulfill the initial request for a 404 page. Further design and functional requirements are pending from the user.