### PR TITLE
Create IDb interface for dependency injection

### DIFF
--- a/IDB_INTERFACE_IMPLEMENTATION.md
+++ b/IDB_INTERFACE_IMPLEMENTATION.md
@@ -1,0 +1,192 @@
+# IDB Interface Implementation
+
+## Overview
+
+This document describes the implementation of the `IDB` interface to improve dependency injection and SOLID principles across the repository. The interface abstracts database operations and enables better separation of concerns between business logic and data access layers.
+
+## What Was Implemented
+
+### 1. IDB Interface Creation
+
+The `IDB` interface was created to abstract database operations:
+
+```typescript
+export interface IDB {
+  // Basic operations that repositories need
+  insert: (table: any) => any;
+  select: () => any;
+  update: (table: any) => any;
+  delete: (table: any) => any;
+  
+  // Transaction support
+  transaction<T>(callback: (tx: any) => Promise<T>): Promise<T>;
+  
+  // Query API for complex queries
+  query: Record<string, any>;
+}
+```
+
+### 2. Location of IDB Interface
+
+The interface is defined in the following locations:
+
+- **`packages/database-utils/src/types/database.ts`** - Shared interface definition
+- **`apps/ledger/src/infrastructure/db/index.ts`** - Local implementation for ledger app
+- **`apps/loan/src/infrastructure/db/index.ts`** - Local implementation for loan app
+
+### 3. Updated Repository Classes
+
+All `BaseRepository` classes have been updated to use the `IDB` interface instead of the concrete `Database` type:
+
+#### Before:
+```typescript
+export class BaseRepository<T, NewT extends Record<string, any>> {
+  constructor(
+    protected db: Database,  // Concrete type
+    protected table: any
+  ) {}
+}
+```
+
+#### After:
+```typescript
+export class BaseRepository<T, NewT extends Record<string, any>> {
+  constructor(
+    protected db: IDB,  // Interface for dependency injection
+    protected table: any
+  ) {}
+}
+```
+
+### 4. Files Modified
+
+- `packages/database-utils/src/types/database.ts` - Added IDB interface
+- `packages/database-utils/src/repository/BaseRepository.ts` - Updated to use IDB
+- `apps/ledger/src/infrastructure/db/index.ts` - Added IDB interface
+- `apps/ledger/src/infrastructure/repositories/baseRepository.ts` - Updated to use IDB
+- `apps/ledger/package.json` - Added database-utils dependency
+- `apps/loan/src/infrastructure/db/index.ts` - Added IDB interface
+- `apps/loan/src/infrastructure/repositories/baseRepository.ts` - Updated to use IDB
+
+## Benefits
+
+### 1. **Improved Dependency Injection**
+- Repositories now depend on an interface rather than a concrete implementation
+- Makes it easier to swap database implementations or create mock implementations for testing
+
+### 2. **Better SOLID Principles**
+- **Dependency Inversion Principle**: High-level modules (repositories) no longer depend on low-level modules (concrete database), both depend on abstractions (IDB interface)
+- **Interface Segregation**: The interface only exposes the operations that repositories actually need
+
+### 3. **Enhanced Testability**
+- You can easily create mock implementations of IDB for unit testing
+- No need to set up a real database connection for testing repository logic
+
+### 4. **Cleaner Architecture**
+- Clear separation between business logic and data access
+- Easier to maintain and extend
+
+## Usage Examples
+
+### 1. Using in Production
+```typescript
+import { db } from "../db";
+import { AccountRepository } from "./accountRepository";
+
+// db already implements IDB interface
+const accountRepo = new AccountRepository(db);
+```
+
+### 2. Testing with Mock Implementation
+```typescript
+const mockDb: IDB = {
+  insert: jest.fn().mockReturnValue({
+    values: jest.fn().mockReturnValue({
+      returning: jest.fn().mockResolvedValue([mockAccount])
+    })
+  }),
+  select: jest.fn().mockReturnValue({
+    from: jest.fn().mockReturnValue({
+      where: jest.fn().mockResolvedValue([mockAccount])
+    })
+  }),
+  // ... other methods
+};
+
+const accountRepo = new AccountRepository(mockDb);
+```
+
+### 3. Custom Database Implementation
+```typescript
+class CustomDatabase implements IDB {
+  insert(table: any) {
+    // Custom implementation
+  }
+  
+  select() {
+    // Custom implementation
+  }
+  
+  // ... other methods
+}
+
+const customDb = new CustomDatabase();
+const accountRepo = new AccountRepository(customDb);
+```
+
+## Migration Guide
+
+### For Existing Code
+
+1. **Repository Constructors**: No changes needed if you're passing the existing `db` instance
+2. **Testing**: You can now create mock implementations of IDB for better unit testing
+3. **New Repositories**: Use the IDB interface in constructor parameter types
+
+### For New Features
+
+1. Always use `IDB` interface in repository constructors
+2. Consider creating mock implementations for testing
+3. Document any new database operations that might need to be added to the interface
+
+## Future Enhancements
+
+### 1. More Specific Interface Methods
+The current interface uses `any` types for flexibility. Consider creating more specific type definitions:
+
+```typescript
+interface IDB {
+  insert<T>(table: Table<T>): InsertBuilder<T>;
+  select<T>(): SelectBuilder<T>;
+  // ... more typed methods
+}
+```
+
+### 2. Database-Specific Interfaces
+Create specific interfaces for different database operations:
+
+```typescript
+interface ITransactionDB extends IDB {
+  transaction<T>(callback: (tx: IDB) => Promise<T>): Promise<T>;
+}
+
+interface IQueryDB extends IDB {
+  query: QueryBuilder;
+}
+```
+
+### 3. Repository Factory Pattern
+Implement a factory pattern to create repositories with proper dependency injection:
+
+```typescript
+class RepositoryFactory {
+  constructor(private db: IDB) {}
+  
+  createAccountRepository(): AccountRepository {
+    return new AccountRepository(this.db);
+  }
+}
+```
+
+## Conclusion
+
+The IDB interface implementation successfully improves dependency injection and SOLID principles across the repository. It provides a clean abstraction layer that enhances testability, maintainability, and extensibility while maintaining compatibility with existing code.

--- a/apps/ledger/package.json
+++ b/apps/ledger/package.json
@@ -24,6 +24,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@repo/database-utils": "workspace:*",
     "@repo/logger": "workspace:*",
     "@supabase/supabase-js": "^2.50.2",
     "cors": "^2.8.5",

--- a/apps/ledger/src/infrastructure/db/index.ts
+++ b/apps/ledger/src/infrastructure/db/index.ts
@@ -10,6 +10,21 @@ import {
   transactionEntryRelations,
 } from "./schemas/transactionEntry";
 
+// Core database interface for dependency injection
+export interface IDB {
+  // Basic operations that repositories need
+  insert: (table: any) => any;
+  select: () => any;
+  update: (table: any) => any;
+  delete: (table: any) => any;
+  
+  // Transaction support
+  transaction<T>(callback: (tx: any) => Promise<T>): Promise<T>;
+  
+  // Query API for complex queries
+  query: Record<string, any>;
+}
+
 const schema = {
   account,
   accountRelations,

--- a/apps/ledger/src/infrastructure/repositories/baseRepository.ts
+++ b/apps/ledger/src/infrastructure/repositories/baseRepository.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import type { Database } from "../db";
+import type { IDB } from "../db";
 
 export interface IBaseRepository<T, NewT extends Record<string, any>> {
   create(data: NewT): Promise<T>;
@@ -11,7 +11,7 @@ export class BaseRepository<T, NewT extends Record<string, any>>
   implements IBaseRepository<T, NewT>
 {
   constructor(
-    protected db: Database,
+    protected db: IDB,
     protected table: any // drizzle table schema
   ) {}
 

--- a/apps/loan/src/infrastructure/db/index.ts
+++ b/apps/loan/src/infrastructure/db/index.ts
@@ -1,6 +1,21 @@
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 
+// Core database interface for dependency injection
+export interface IDB {
+  // Basic operations that repositories need
+  insert: (table: any) => any;
+  select: () => any;
+  update: (table: any) => any;
+  delete: (table: any) => any;
+  
+  // Transaction support
+  transaction<T>(callback: (tx: any) => Promise<T>): Promise<T>;
+  
+  // Query API for complex queries
+  query: Record<string, any>;
+}
+
 const connStr = process.env.DATABASE_URL;
 
 if (!connStr) {
@@ -11,4 +26,4 @@ export const client = postgres(connStr, { prepare: false });
 
 export const db = drizzle(client);
 
-export type { Database } from "@repo/database-utils";
+export type Database = typeof db;

--- a/apps/loan/src/infrastructure/repositories/baseRepository.ts
+++ b/apps/loan/src/infrastructure/repositories/baseRepository.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import type { Database } from "../db";
+import type { IDB } from "../db";
 
 export interface IBaseRepository<T, NewT extends Record<string, any>> {
   create(data: NewT): Promise<T>;
@@ -11,7 +11,7 @@ export class BaseRepository<T, NewT extends Record<string, any>>
   implements IBaseRepository<T, NewT>
 {
   constructor(
-    protected db: Database,
+    protected db: IDB,
     protected table: any // drizzle table schema
   ) {}
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
     "apps/ledger": {
       "name": "ledger",
       "dependencies": {
+        "@repo/database-utils": "workspace:*",
         "@repo/logger": "workspace:*",
         "@supabase/supabase-js": "^2.50.2",
         "cors": "^2.8.5",
@@ -732,7 +733,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.2.17", "", { "dependencies": { "bun-types": "1.2.17" } }, "sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q=="],
+    "@types/bun": ["@types/bun@1.2.18", "", { "dependencies": { "bun-types": "1.2.18" } }, "sha512-Xf6RaWVheyemaThV0kUfaAUvCNokFr+bH8Jxp+tTZfx7dAPA8z9ePnP9S9+Vspzuxxx9JRAXhnyccRj3GyCMdQ=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -2156,6 +2157,8 @@
 
     "@types/body-parser/@types/node": ["@types/node@22.15.34", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw=="],
 
+    "@types/bun/bun-types": ["bun-types@1.2.18", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-04+Eha5NP7Z0A9YgDAzMk5PHR16ZuLVa83b26kH5+cp1qZW4F6FmAURngE7INf4tKOvCE69vYvDEwoNl1tGiWw=="],
+
     "@types/connect/@types/node": ["@types/node@22.15.34", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw=="],
 
     "@types/cors/@types/node": ["@types/node@22.15.34", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw=="],
@@ -2241,6 +2244,8 @@
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "lightningcss/detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
+
+    "loan/@types/bun": ["@types/bun@1.2.17", "", { "dependencies": { "bun-types": "1.2.17" } }, "sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q=="],
 
     "log-symbols/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
 
@@ -2387,6 +2392,8 @@
     "@ts-morph/common/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "@types/bun/bun-types/@types/node": ["@types/node@22.15.34", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw=="],
 
     "@typescript-eslint/typescript-estree/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/packages/database-utils/src/repository/BaseRepository.ts
+++ b/packages/database-utils/src/repository/BaseRepository.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import type { Database } from "../types/database";
+import type { IDB } from "../types/database";
 
 export interface IBaseRepository<T, NewT extends Record<string, any>> {
   create(data: NewT): Promise<T>;
@@ -11,7 +11,7 @@ export class BaseRepository<T, NewT extends Record<string, any>>
   implements IBaseRepository<T, NewT>
 {
   constructor(
-    protected db: Database,
+    protected db: IDB,
     protected table: any // drizzle table schema
   ) {}
 

--- a/packages/database-utils/src/types/database.ts
+++ b/packages/database-utils/src/types/database.ts
@@ -1,3 +1,19 @@
 import type { PgDatabase } from "drizzle-orm/pg-core";
 
-export type Database = PgDatabase<Record<string, never>>;
+// Core database interface for dependency injection
+export interface IDB {
+  // Basic operations that repositories need
+  insert: (table: any) => any;
+  select: () => any;
+  update: (table: any) => any;
+  delete: (table: any) => any;
+  
+  // Transaction support
+  transaction<T>(callback: (tx: any) => Promise<T>): Promise<T>;
+  
+  // Query API for complex queries
+  query: Record<string, any>;
+}
+
+// Extend the existing Database type to implement IDB
+export type Database = PgDatabase<Record<string, never>> & IDB;


### PR DESCRIPTION
Introduce `IDB` interface and update repository constructors to use it, enhancing dependency injection and SOLID principles.