### PR TITLE
chore: Check account IDs in transaction creation

### DIFF
--- a/apps/ledger/src/application/useCases/transaction/createTransactionUseCase.test.ts
+++ b/apps/ledger/src/application/useCases/transaction/createTransactionUseCase.test.ts
@@ -1,0 +1,176 @@
+import CreateTransactionUseCase from "./createTransactionUseCase";
+import type { ITransactionRepository } from "../../../infrastructure/repositories/transactionRepository";
+import type { ITransactionEntryRepository } from "../../../infrastructure/repositories/transactionEntryRepository";
+import type { IAccountRepository } from "../../../infrastructure/repositories/accountRepository";
+import type { TransactionDTO } from "../../../presentation/validators/transactionSchema";
+import type { Account } from "../../../infrastructure/db/schemas/account";
+import type { Transaction } from "../../../infrastructure/db/schemas/transaction";
+
+describe("CreateTransactionUseCase", () => {
+  let createTransactionUseCase: CreateTransactionUseCase;
+  let mockTransactionRepository: jest.Mocked<ITransactionRepository>;
+  let mockTransactionEntryRepository: jest.Mocked<ITransactionEntryRepository>;
+  let mockAccountRepository: jest.Mocked<IAccountRepository>;
+
+  beforeEach(() => {
+    mockTransactionRepository = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findAll: jest.fn(),
+      findByEventType: jest.fn(),
+    };
+
+    mockTransactionEntryRepository = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findAll: jest.fn(),
+      createBatch: jest.fn(),
+    };
+
+    mockAccountRepository = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findAll: jest.fn(),
+    };
+
+    createTransactionUseCase = new CreateTransactionUseCase(
+      mockTransactionRepository,
+      mockTransactionEntryRepository,
+      mockAccountRepository
+    );
+  });
+
+  describe("execute", () => {
+    it("should create a transaction when all accounts exist", async () => {
+      const transactionDTO: TransactionDTO = {
+        eventType: "test-event",
+        description: "Test transaction",
+        ledgerId: "ledger-123",
+        status: "active",
+        entries: [
+          {
+            accountId: "account-123",
+            direction: "debit",
+            amountField: "amount",
+          },
+          {
+            accountId: "account-456",
+            direction: "credit",
+            amountField: "amount",
+          },
+        ],
+      };
+
+      const mockAccount: Account = {
+        id: "account-123",
+        name: "Test Account",
+        description: "Test",
+        accountType: "asset",
+        metadata: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ledgerId: "ledger-123",
+      };
+
+      const mockTransaction: Transaction = {
+        id: "transaction-123",
+        eventType: "test-event",
+        description: "Test transaction",
+        ledgerId: "ledger-123",
+        status: "active",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockAccountRepository.findById.mockResolvedValue(mockAccount);
+      mockTransactionRepository.create.mockResolvedValue(mockTransaction);
+      mockTransactionEntryRepository.createBatch.mockResolvedValue();
+
+      const result = await createTransactionUseCase.execute(transactionDTO);
+
+      expect(mockAccountRepository.findById).toHaveBeenCalledWith("account-123");
+      expect(mockAccountRepository.findById).toHaveBeenCalledWith("account-456");
+      expect(mockTransactionRepository.create).toHaveBeenCalled();
+      expect(mockTransactionEntryRepository.createBatch).toHaveBeenCalled();
+      expect(result).toBe(mockTransaction);
+    });
+
+    it("should throw an error when an account does not exist", async () => {
+      const transactionDTO: TransactionDTO = {
+        eventType: "test-event",
+        description: "Test transaction",
+        ledgerId: "ledger-123",
+        status: "active",
+        entries: [
+          {
+            accountId: "non-existent-account",
+            direction: "debit",
+            amountField: "amount",
+          },
+        ],
+      };
+
+      mockAccountRepository.findById.mockResolvedValue(null);
+
+      await expect(createTransactionUseCase.execute(transactionDTO)).rejects.toThrow(
+        "Failed to create transaction: Account with ID non-existent-account not found"
+      );
+
+      expect(mockAccountRepository.findById).toHaveBeenCalledWith("non-existent-account");
+      expect(mockTransactionRepository.create).not.toHaveBeenCalled();
+      expect(mockTransactionEntryRepository.createBatch).not.toHaveBeenCalled();
+    });
+
+    it("should validate unique account IDs only once", async () => {
+      const transactionDTO: TransactionDTO = {
+        eventType: "test-event",
+        description: "Test transaction",
+        ledgerId: "ledger-123",
+        status: "active",
+        entries: [
+          {
+            accountId: "account-123",
+            direction: "debit",
+            amountField: "amount",
+          },
+          {
+            accountId: "account-123", // Same account ID
+            direction: "credit",
+            amountField: "amount",
+          },
+        ],
+      };
+
+      const mockAccount: Account = {
+        id: "account-123",
+        name: "Test Account",
+        description: "Test",
+        accountType: "asset",
+        metadata: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ledgerId: "ledger-123",
+      };
+
+      const mockTransaction: Transaction = {
+        id: "transaction-123",
+        eventType: "test-event",
+        description: "Test transaction",
+        ledgerId: "ledger-123",
+        status: "active",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockAccountRepository.findById.mockResolvedValue(mockAccount);
+      mockTransactionRepository.create.mockResolvedValue(mockTransaction);
+      mockTransactionEntryRepository.createBatch.mockResolvedValue();
+
+      await createTransactionUseCase.execute(transactionDTO);
+
+      // Should only be called once for the unique account ID
+      expect(mockAccountRepository.findById).toHaveBeenCalledTimes(1);
+      expect(mockAccountRepository.findById).toHaveBeenCalledWith("account-123");
+    });
+  });
+});

--- a/apps/ledger/src/application/useCases/transaction/createTransactionUseCase.ts
+++ b/apps/ledger/src/application/useCases/transaction/createTransactionUseCase.ts
@@ -5,20 +5,24 @@ import type {
 } from "../../../infrastructure/db/schemas/transaction";
 import type { TransactionDTO } from "../../../presentation/validators/transactionSchema";
 import type { ITransactionEntryRepository } from "../../../infrastructure/repositories/transactionEntryRepository";
+import type { IAccountRepository } from "../../../infrastructure/repositories/accountRepository";
 
 export default class CreateTransactionUseCase {
   constructor(
     private transactionRepository: ITransactionRepository,
-    private transactionEntryRepository: ITransactionEntryRepository
+    private transactionEntryRepository: ITransactionEntryRepository,
+    private accountRepository: IAccountRepository
   ) {}
 
   async execute(data: TransactionDTO): Promise<Transaction> {
     try {
+      // Validate that all accounts exist and are active
+      await this.validateAccountsExist(data.entries);
+
       const transaction = await this.transactionRepository.create(
         this.mapDTOToTransaction(data)
       );
 
-      //TODO Add account validation: check if account exists and is active
       const entries = data.entries.map((entry) => ({
         ...entry,
         transactionId: transaction.id,
@@ -28,7 +32,19 @@ export default class CreateTransactionUseCase {
 
       return transaction;
     } catch (error) {
-      throw new Error(`Failed to create account: ${error}`);
+      throw new Error(`Failed to create transaction: ${error}`);
+    }
+  }
+
+  private async validateAccountsExist(entries: TransactionDTO['entries']): Promise<void> {
+    const accountIds = entries.map(entry => entry.accountId);
+    const uniqueAccountIds = [...new Set(accountIds)];
+
+    for (const accountId of uniqueAccountIds) {
+      const account = await this.accountRepository.findById(accountId);
+      if (!account) {
+        throw new Error(`Account with ID ${accountId} not found`);
+      }
     }
   }
 

--- a/apps/ledger/src/application/useCases/transaction/createTransactionUseCase.ts
+++ b/apps/ledger/src/application/useCases/transaction/createTransactionUseCase.ts
@@ -16,8 +16,7 @@ export default class CreateTransactionUseCase {
 
   async execute(data: TransactionDTO): Promise<Transaction> {
     try {
-      // Validate that all accounts exist and are active
-      await this.validateAccountsExist(data.entries);
+      await this.validateAccounts(data.entries);
 
       const transaction = await this.transactionRepository.create(
         this.mapDTOToTransaction(data)
@@ -32,13 +31,16 @@ export default class CreateTransactionUseCase {
 
       return transaction;
     } catch (error) {
-      throw new Error(`Failed to create transaction: ${error}`);
+      throw new Error(error as string);
     }
   }
 
-  private async validateAccountsExist(entries: TransactionDTO['entries']): Promise<void> {
-    const accountIds = entries.map(entry => entry.accountId);
-    const uniqueAccountIds = [...new Set(accountIds)];
+  private async validateAccounts(
+    entries: TransactionDTO["entries"]
+  ): Promise<void> {
+    const uniqueAccountIds = [
+      ...new Set(entries.map((entry) => entry.accountId)),
+    ];
 
     for (const accountId of uniqueAccountIds) {
       const account = await this.accountRepository.findById(accountId);

--- a/apps/ledger/src/application/useCases/transaction/getTransactionsUseCase.ts
+++ b/apps/ledger/src/application/useCases/transaction/getTransactionsUseCase.ts
@@ -15,7 +15,7 @@ export default class GetTransactionsUseCase {
 
       return transactions;
     } catch (error) {
-      throw new Error(`Failed to fetch transactions: ${error}`);
+      throw new Error(error as string);
     }
   }
 }

--- a/apps/ledger/src/infrastructure/repositories/transactionRepository.ts
+++ b/apps/ledger/src/infrastructure/repositories/transactionRepository.ts
@@ -24,11 +24,12 @@ export class TransactionRepository
   async findByEventType(
     eventType: string
   ): Promise<CompleteTransaction | null> {
+    const eventFilter = eventType
+      ? eq(transaction.eventType, eventType)
+      : undefined;
+
     const result = await this.db.query.transaction.findFirst({
-      where: and(
-        eq(transaction.eventType, eventType),
-        eq(transaction.status, "active")
-      ),
+      where: and(eventFilter, eq(transaction.status, "active")),
       with: {
         entries: true,
       },

--- a/apps/ledger/src/presentation/handlers/transactionHandler.ts
+++ b/apps/ledger/src/presentation/handlers/transactionHandler.ts
@@ -5,11 +5,13 @@ import type { ApiResponse } from "../types/api";
 import { transactionSchema } from "../validators/transactionSchema";
 import CreateTransactionUseCase from "../../application/useCases/transaction/createTransactionUseCase";
 import { TransactionEntryRepository } from "../../infrastructure/repositories/transactionEntryRepository";
+import { AccountRepository } from "../../infrastructure/repositories/accountRepository";
 import GetTransactionsUseCase from "../../application/useCases/transaction/getTransactionsUseCase";
 import GetTransactionUseCase from "../../application/useCases/transaction/getTransactionUseCase";
 
 const transactionRepository = new TransactionRepository(db);
 const transactionEntryRepository = new TransactionEntryRepository(db);
+const accountRepository = new AccountRepository(db);
 
 export const createTransaction = async (req: Request, res: Response) => {
   try {
@@ -25,7 +27,8 @@ export const createTransaction = async (req: Request, res: Response) => {
 
     const createTransactionUseCase = new CreateTransactionUseCase(
       transactionRepository,
-      transactionEntryRepository
+      transactionEntryRepository,
+      accountRepository
     );
 
     const transaction = await createTransactionUseCase.execute(validation.data);


### PR DESCRIPTION
Add account ID validation to transaction creation to ensure all referenced accounts exist.