### PR TITLE
feat: Validate UUID entries for improving error handling

### DIFF
--- a/apps/ledger/src/lib/validation.test.ts
+++ b/apps/ledger/src/lib/validation.test.ts
@@ -1,0 +1,79 @@
+import { validateUUID, validateUUIDs } from "./validation";
+
+describe("UUID Validation", () => {
+  describe("validateUUID", () => {
+    it("should return valid for a correct UUID", () => {
+      const validUUID = "123e4567-e89b-12d3-a456-426614174000";
+      const result = validateUUID(validUUID);
+      
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("should return invalid for an incorrect UUID format", () => {
+      const invalidUUID = "invalid-uuid";
+      const result = validateUUID(invalidUUID);
+      
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe("Invalid UUID format");
+    });
+
+    it("should return invalid for empty string", () => {
+      const emptyString = "";
+      const result = validateUUID(emptyString);
+      
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe("Invalid UUID format");
+    });
+
+    it("should return invalid for UUID with wrong length", () => {
+      const wrongLength = "123e4567-e89b-12d3-a456";
+      const result = validateUUID(wrongLength);
+      
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe("Invalid UUID format");
+    });
+
+    it("should return invalid for UUID with invalid characters", () => {
+      const invalidChars = "123e4567-e89b-12d3-a456-42661417400g";
+      const result = validateUUID(invalidChars);
+      
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBe("Invalid UUID format");
+    });
+  });
+
+  describe("validateUUIDs", () => {
+    it("should return valid for array of correct UUIDs", () => {
+      const validUUIDs = [
+        "123e4567-e89b-12d3-a456-426614174000",
+        "987fcdeb-51a2-43d1-9876-543210987654"
+      ];
+      const result = validateUUIDs(validUUIDs);
+      
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    });
+
+    it("should return invalid for array with some invalid UUIDs", () => {
+      const mixedUUIDs = [
+        "123e4567-e89b-12d3-a456-426614174000", // valid
+        "invalid-uuid", // invalid
+        "987fcdeb-51a2-43d1-9876-543210987654" // valid
+      ];
+      const result = validateUUIDs(mixedUUIDs);
+      
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors?.[0]).toContain("Invalid UUID at position 1");
+    });
+
+    it("should return valid for empty array", () => {
+      const emptyArray: string[] = [];
+      const result = validateUUIDs(emptyArray);
+      
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    });
+  });
+});

--- a/apps/ledger/src/lib/validation.ts
+++ b/apps/ledger/src/lib/validation.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+// UUID validation schema
+const uuidSchema = z.string().uuid();
+
+/**
+ * Validates if a string is a valid UUID
+ * @param id - The string to validate
+ * @returns object with isValid boolean and error message if invalid
+ */
+export const validateUUID = (id: string): { isValid: boolean; error?: string } => {
+  const result = uuidSchema.safeParse(id);
+  
+  if (!result.success) {
+    return {
+      isValid: false,
+      error: "Invalid UUID format"
+    };
+  }
+  
+  return { isValid: true };
+};
+
+/**
+ * Validates multiple UUIDs
+ * @param ids - Array of strings to validate
+ * @returns object with isValid boolean and errors array if any are invalid
+ */
+export const validateUUIDs = (ids: string[]): { isValid: boolean; errors?: string[] } => {
+  const errors: string[] = [];
+  
+  ids.forEach((id, index) => {
+    const validation = validateUUID(id);
+    if (!validation.isValid) {
+      errors.push(`Invalid UUID at position ${index}: ${id}`);
+    }
+  });
+  
+  if (errors.length > 0) {
+    return {
+      isValid: false,
+      errors
+    };
+  }
+  
+  return { isValid: true };
+};

--- a/apps/ledger/src/presentation/handlers/accountBalanceHandler.ts
+++ b/apps/ledger/src/presentation/handlers/accountBalanceHandler.ts
@@ -8,6 +8,7 @@ import {
   createPaginationInfo,
 } from "@repo/utils/api";
 import { db } from "../../infrastructure/db";
+import { validateUUID } from "../../lib/validation";
 
 const entryRepo = new EntryRepository(db);
 
@@ -46,6 +47,15 @@ export const getAccountBalances = async (req: Request, res: Response) => {
     }
 
     if (ledgerId) {
+      // Validate UUID format
+      const uuidValidation = validateUUID(ledgerId as string);
+      if (!uuidValidation.isValid) {
+        const response = createErrorResponse(
+          "Invalid ledger ID format",
+          uuidValidation.error
+        );
+        return res.status(400).json(response);
+      }
       filters.ledgerId = ledgerId as string;
     }
 

--- a/apps/ledger/src/presentation/handlers/accountHandler.ts
+++ b/apps/ledger/src/presentation/handlers/accountHandler.ts
@@ -16,6 +16,7 @@ import {
   GetAccountUseCase,
   GetAccountsUseCase,
 } from "../../application/useCases/account";
+import { validateUUID } from "../../lib/validation";
 
 const accountRepo = new AccountRepository(db);
 
@@ -58,6 +59,16 @@ export const getAccount = async (req: Request, res: Response) => {
 
     if (!id) {
       const response = createErrorResponse("Account ID is required");
+      return res.status(400).json(response);
+    }
+
+    // Validate UUID format
+    const uuidValidation = validateUUID(id);
+    if (!uuidValidation.isValid) {
+      const response = createErrorResponse(
+        "Invalid account ID format",
+        uuidValidation.error
+      );
       return res.status(400).json(response);
     }
 

--- a/apps/ledger/src/presentation/handlers/journalHandler.ts
+++ b/apps/ledger/src/presentation/handlers/journalHandler.ts
@@ -15,6 +15,7 @@ import {
   parsePaginationParams,
   createPaginationInfo,
 } from "@repo/utils/api";
+import { validateUUID } from "../../lib/validation";
 
 const journalRepo = new JournalRepository(db);
 const entryRepo = new EntryRepository(db);
@@ -64,6 +65,16 @@ export const getJournal = async (req: Request, res: Response) => {
       return res.status(400).json(response);
     }
 
+    // Validate UUID format
+    const uuidValidation = validateUUID(id);
+    if (!uuidValidation.isValid) {
+      const response = createErrorResponse(
+        "Invalid journal ID format",
+        uuidValidation.error
+      );
+      return res.status(400).json(response);
+    }
+
     const useCase = new GetJournalUseCase(journalRepo, entryRepo);
     const journal = await useCase.execute(id);
 
@@ -91,6 +102,18 @@ export const getJournals = async (req: Request, res: Response) => {
     const ledgerId = req.query.ledgerId as string | undefined;
     const { page = 1, limit = 10 } = parsePaginationParams(req.query);
     const offset = (page - 1) * limit;
+
+    // Validate ledgerId UUID format if provided
+    if (ledgerId) {
+      const uuidValidation = validateUUID(ledgerId);
+      if (!uuidValidation.isValid) {
+        const response = createErrorResponse(
+          "Invalid ledger ID format",
+          uuidValidation.error
+        );
+        return res.status(400).json(response);
+      }
+    }
 
     const useCase = new GetJournalsUseCase(journalRepo, entryRepo);
     const journals = await useCase.execute(ledgerId);

--- a/apps/ledger/src/presentation/handlers/ledgerHandler.ts
+++ b/apps/ledger/src/presentation/handlers/ledgerHandler.ts
@@ -14,6 +14,7 @@ import {
   createPaginationInfo,
 } from "@repo/utils/api";
 import logger from "@repo/logger";
+import { validateUUID } from "../../lib/validation";
 
 const ledgerRepo = new LedgerRepository(db);
 
@@ -56,6 +57,16 @@ export const getLedger = async (req: Request, res: Response) => {
 
     if (!id) {
       const response = createErrorResponse("Ledger ID is required");
+      return res.status(400).json(response);
+    }
+
+    // Validate UUID format
+    const uuidValidation = validateUUID(id);
+    if (!uuidValidation.isValid) {
+      const response = createErrorResponse(
+        "Invalid ledger ID format",
+        uuidValidation.error
+      );
       return res.status(400).json(response);
     }
 

--- a/apps/ledger/src/presentation/handlers/transactionHandler.ts
+++ b/apps/ledger/src/presentation/handlers/transactionHandler.ts
@@ -7,6 +7,7 @@ import {
   formatZodErrors,
 } from "@repo/utils/api";
 import { transactionSchema } from "../validators/transactionSchema";
+import { validateUUID } from "../../lib/validation";
 import CreateTransactionUseCase from "../../application/useCases/transaction/createTransactionUseCase";
 import { TransactionEntryRepository } from "../../infrastructure/repositories/transactionEntryRepository";
 import { AccountRepository } from "../../infrastructure/repositories/accountRepository";
@@ -59,6 +60,16 @@ export const getTransaction = async (req: Request, res: Response) => {
 
     if (!id) {
       const response = createErrorResponse("Transaction ID is required");
+      return res.status(400).json(response);
+    }
+
+    // Validate UUID format
+    const uuidValidation = validateUUID(id);
+    if (!uuidValidation.isValid) {
+      const response = createErrorResponse(
+        "Invalid transaction ID format",
+        uuidValidation.error
+      );
       return res.status(400).json(response);
     }
 


### PR DESCRIPTION
On /:id get api calls, add UUID validation to API handlers to provide proper error handling for invalid ID formats.