### PR TITLE
feat: enhance listJournals with date filtering

### DIFF
--- a/apps/ledger/src/application/useCases/journal/getJournalsUseCase.ts
+++ b/apps/ledger/src/application/useCases/journal/getJournalsUseCase.ts
@@ -11,17 +11,21 @@ import type { Account } from "../../../infrastructure/db/schemas/account";
 import { formatDate } from "date-fns";
 import type { AccountType } from "../../types/account";
 
+export interface GetJournalsFilters {
+  startDate?: Date;
+  endDate?: Date;
+  ledgerId?: string;
+}
+
 export default class GetJournalsUseCase {
   constructor(
     private journalRepository: IJournalRepository,
     private entryRepository: IEntryRepository
   ) {}
 
-  async execute(ledgerId?: string): Promise<JournalResponseDTO[]> {
-    // 1. Find relevant journals - either all or by ledger
-    const journals = ledgerId
-      ? await this.journalRepository.findByLedgerId(ledgerId)
-      : await this.journalRepository.findAll();
+  async execute(filters?: GetJournalsFilters): Promise<JournalResponseDTO[]> {
+    // 1. Find relevant journals with filters and ordering
+    const journals = await this.journalRepository.findWithFilters(filters);
 
     // 2. For each journal fetch its entries (with account details)
     const results: CompleteJournal[] = [];

--- a/apps/ledger/src/application/useCases/journal/index.ts
+++ b/apps/ledger/src/application/useCases/journal/index.ts
@@ -2,4 +2,4 @@
 export { default } from "./createJournalUseCase";
 export { default as CreateJournalUseCase } from "./createJournalUseCase";
 export { default as GetJournalUseCase } from "./getJournalUseCase";
-export { default as GetJournalsUseCase } from "./getJournalsUseCase";
+export { default as GetJournalsUseCase, type GetJournalsFilters } from "./getJournalsUseCase";

--- a/apps/ledger/src/infrastructure/repositories/journalRepository.ts
+++ b/apps/ledger/src/infrastructure/repositories/journalRepository.ts
@@ -2,12 +2,14 @@ import type { Database } from "../db";
 import { journal, type Journal, type NewJournal } from "../db/schemas/journal";
 import { entry } from "../db/schemas/entry";
 import { account } from "../db/schemas/account";
-import { eq } from "drizzle-orm";
+import { eq, and, gte, lte, desc } from "drizzle-orm";
 import { BaseRepository, type IBaseRepository } from "./baseRepository";
+import type { GetJournalsFilters } from "../../application/useCases/journal/getJournalsUseCase";
 
 export interface IJournalRepository
   extends IBaseRepository<Journal, NewJournal> {
   findByLedgerId(ledgerId: string): Promise<Journal[]>;
+  findWithFilters(filters?: GetJournalsFilters): Promise<Journal[]>;
 }
 
 export class JournalRepository
@@ -28,6 +30,37 @@ export class JournalRepository
       .select()
       .from(journal)
       .where(eq(journal.ledgerId, ledgerId));
+
+    return result as Journal[];
+  }
+
+  /**
+   * Find journals with optional filtering by date range and ledger ID.
+   * Results are ordered by code in descending order.
+   */
+  async findWithFilters(filters?: GetJournalsFilters): Promise<Journal[]> {
+    // Build dynamic where conditions
+    const conditions = [];
+
+    if (filters?.startDate) {
+      conditions.push(gte(journal.postingDate, filters.startDate));
+    }
+
+    if (filters?.endDate) {
+      conditions.push(lte(journal.postingDate, filters.endDate));
+    }
+
+    if (filters?.ledgerId) {
+      conditions.push(eq(journal.ledgerId, filters.ledgerId));
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const result = await this.db
+      .select()
+      .from(journal)
+      .where(whereClause)
+      .orderBy(desc(journal.code));
 
     return result as Journal[];
   }

--- a/apps/ledger/src/presentation/handlers/journalHandler.ts
+++ b/apps/ledger/src/presentation/handlers/journalHandler.ts
@@ -88,12 +88,44 @@ export const getJournal = async (req: Request, res: Response) => {
 
 export const getJournals = async (req: Request, res: Response) => {
   try {
-    const ledgerId = req.query.ledgerId as string | undefined;
+    const { startDate, endDate, ledgerId } = req.query;
     const { page = 1, limit = 10 } = parsePaginationParams(req.query);
     const offset = (page - 1) * limit;
 
+    const filters: {
+      startDate?: Date;
+      endDate?: Date;
+      ledgerId?: string;
+    } = {};
+
+    if (startDate) {
+      const parsedStartDate = new Date(startDate as string);
+      if (isNaN(parsedStartDate.getTime())) {
+        const response = createErrorResponse(
+          "Invalid startDate format. Use ISO date format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss.sssZ)"
+        );
+        return res.status(400).json(response);
+      }
+      filters.startDate = parsedStartDate;
+    }
+
+    if (endDate) {
+      const parsedEndDate = new Date(endDate as string);
+      if (isNaN(parsedEndDate.getTime())) {
+        const response = createErrorResponse(
+          "Invalid endDate format. Use ISO date format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss.sssZ)"
+        );
+        return res.status(400).json(response);
+      }
+      filters.endDate = parsedEndDate;
+    }
+
+    if (ledgerId) {
+      filters.ledgerId = ledgerId as string;
+    }
+
     const useCase = new GetJournalsUseCase(journalRepo, entryRepo);
-    const journals = await useCase.execute(ledgerId);
+    const journals = await useCase.execute(filters);
 
     // Apply pagination to the results
     const paginatedJournals = journals.slice(offset, offset + limit);


### PR DESCRIPTION
Add date range filtering and descending code ordering to the `getJournals` endpoint to enhance journal retrieval capabilities.

The implementation allows filtering by `startDate` and `endDate` on the `postingDate` field and ensures results are ordered by `code` in descending order, aligning with user requirements for improved data querying.