### PR TITLE
chore Enable account filtering accounts by ledgerId

### DIFF
--- a/apps/ledger/src/application/useCases/account/getAccountsUseCase.ts
+++ b/apps/ledger/src/application/useCases/account/getAccountsUseCase.ts
@@ -1,12 +1,16 @@
 import type { IAccountRepository } from "../../../infrastructure/repositories/accountRepository";
 import type { Account } from "../../../infrastructure/db/schemas/account";
 
+export interface GetAccountsFilters {
+  accountId?: string;
+}
+
 export default class GetAccountsUseCase {
   constructor(private accountRepository: IAccountRepository) {}
 
-  async execute(): Promise<Account[]> {
+  async execute(filters?: GetAccountsFilters): Promise<Account[]> {
     try {
-      const accounts = await this.accountRepository.findAll();
+      const accounts = await this.accountRepository.findAll(filters);
       return accounts;
     } catch (error) {
       throw new Error(`Failed to fetch accounts: ${error}`);

--- a/apps/ledger/src/application/useCases/account/getAccountsUseCase.ts
+++ b/apps/ledger/src/application/useCases/account/getAccountsUseCase.ts
@@ -2,7 +2,7 @@ import type { IAccountRepository } from "../../../infrastructure/repositories/ac
 import type { Account } from "../../../infrastructure/db/schemas/account";
 
 export interface GetAccountsFilters {
-  accountId?: string;
+  ledgerId?: string;
 }
 
 export default class GetAccountsUseCase {

--- a/apps/ledger/src/application/useCases/account/getAccountsUseCase.ts
+++ b/apps/ledger/src/application/useCases/account/getAccountsUseCase.ts
@@ -1,16 +1,12 @@
 import type { IAccountRepository } from "../../../infrastructure/repositories/accountRepository";
 import type { Account } from "../../../infrastructure/db/schemas/account";
 
-export interface GetAccountsFilters {
-  ledgerId?: string;
-}
-
 export default class GetAccountsUseCase {
   constructor(private accountRepository: IAccountRepository) {}
 
-  async execute(filters?: GetAccountsFilters): Promise<Account[]> {
+  async execute(ledgerId?: string): Promise<Account[]> {
     try {
-      const accounts = await this.accountRepository.findAll(filters);
+      const accounts = await this.accountRepository.findAll({ ledgerId });
       return accounts;
     } catch (error) {
       throw new Error(`Failed to fetch accounts: ${error}`);

--- a/apps/ledger/src/application/useCases/account/index.ts
+++ b/apps/ledger/src/application/useCases/account/index.ts
@@ -1,5 +1,5 @@
 export { default } from "./createAccountUseCase";
 export { default as CreateAccountUseCase } from "./createAccountUseCase";
 export { default as GetAccountUseCase } from "./getAccountUseCase";
-export { default as GetAccountsUseCase } from "./getAccountsUseCase";
+export { default as GetAccountsUseCase, type GetAccountsFilters } from "./getAccountsUseCase";
 export { default as GetAccountBalancesUseCase } from "./getAccountBalancesUseCase";

--- a/apps/ledger/src/infrastructure/repositories/accountRepository.ts
+++ b/apps/ledger/src/infrastructure/repositories/accountRepository.ts
@@ -15,17 +15,11 @@ export class AccountRepository
   }
 
   override async findAll(filters?: { ledgerId?: string }): Promise<Account[]> {
-    if (filters?.ledgerId) {
-      // If ledgerId filter is provided, return all accounts from that ledger
-      const result = await this.db
-        .select()
-        .from(account)
-        .where(eq(account.ledgerId, filters.ledgerId));
-      return result as Account[];
-    }
-    
-    // If no filters, return all accounts
-    const result = await this.db.select().from(account);
+    const whereClause = filters?.ledgerId
+      ? eq(account.ledgerId, filters.ledgerId)
+      : undefined;
+
+    const result = await this.db.select().from(account).where(whereClause);
     return result as Account[];
   }
 }

--- a/apps/ledger/src/infrastructure/repositories/accountRepository.ts
+++ b/apps/ledger/src/infrastructure/repositories/accountRepository.ts
@@ -14,13 +14,13 @@ export class AccountRepository
     super(db, account);
   }
 
-  override async findAll(filters?: { accountId?: string }): Promise<Account[]> {
-    if (filters?.accountId) {
-      // If accountId filter is provided, return that specific account
+  override async findAll(filters?: { ledgerId?: string }): Promise<Account[]> {
+    if (filters?.ledgerId) {
+      // If ledgerId filter is provided, return all accounts from that ledger
       const result = await this.db
         .select()
         .from(account)
-        .where(eq(account.id, filters.accountId));
+        .where(eq(account.ledgerId, filters.ledgerId));
       return result as Account[];
     }
     

--- a/apps/ledger/src/infrastructure/repositories/accountRepository.ts
+++ b/apps/ledger/src/infrastructure/repositories/accountRepository.ts
@@ -1,6 +1,7 @@
 import type { Database } from "../db";
 import { account, type Account, type NewAccount } from "../db/schemas/account";
 import { BaseRepository, type IBaseRepository } from "./baseRepository";
+import { eq } from "drizzle-orm";
 
 export interface IAccountRepository
   extends IBaseRepository<Account, NewAccount> {}
@@ -11,5 +12,20 @@ export class AccountRepository
 {
   constructor(db: Database) {
     super(db, account);
+  }
+
+  override async findAll(filters?: { accountId?: string }): Promise<Account[]> {
+    if (filters?.accountId) {
+      // If accountId filter is provided, return that specific account
+      const result = await this.db
+        .select()
+        .from(account)
+        .where(eq(account.id, filters.accountId));
+      return result as Account[];
+    }
+    
+    // If no filters, return all accounts
+    const result = await this.db.select().from(account);
+    return result as Account[];
   }
 }

--- a/apps/ledger/src/infrastructure/repositories/baseRepository.ts
+++ b/apps/ledger/src/infrastructure/repositories/baseRepository.ts
@@ -4,7 +4,7 @@ import type { Database } from "../db";
 export interface IBaseRepository<T, NewT extends Record<string, any>> {
   create(data: NewT): Promise<T>;
   findById(id: string): Promise<T | null>;
-  findAll(): Promise<T[]>;
+  findAll(filters?: Record<string, any>): Promise<T[]>;
 }
 
 export class BaseRepository<T, NewT extends Record<string, any>>
@@ -28,7 +28,7 @@ export class BaseRepository<T, NewT extends Record<string, any>>
     return result[0] ? (result[0] as T) : null;
   }
 
-  async findAll(): Promise<T[]> {
+  async findAll(filters?: Record<string, any>): Promise<T[]> {
     const result = await this.db.select().from(this.table);
     return result as T[];
   }

--- a/apps/ledger/src/presentation/handlers/accountHandler.ts
+++ b/apps/ledger/src/presentation/handlers/accountHandler.ts
@@ -87,15 +87,15 @@ export const getAccount = async (req: Request, res: Response) => {
 export const getAccounts = async (req: Request, res: Response) => {
   try {
     const { page = 1, limit = 10 } = parsePaginationParams(req.query);
-    const { accountId } = req.query;
+    const { ledgerId } = req.query;
     const offset = (page - 1) * limit;
 
     const filters: GetAccountsFilters = {};
     
-    if (accountId) {
-      // Validate that accountId is a valid UUID if provided
-      if (typeof accountId === 'string' && accountId.length > 0) {
-        filters.accountId = accountId;
+    if (ledgerId) {
+      // Validate that ledgerId is a valid UUID if provided
+      if (typeof ledgerId === 'string' && ledgerId.length > 0) {
+        filters.ledgerId = ledgerId;
       }
     }
 

--- a/apps/ledger/src/presentation/handlers/accountHandler.ts
+++ b/apps/ledger/src/presentation/handlers/accountHandler.ts
@@ -15,7 +15,6 @@ import {
   CreateAccountUseCase,
   GetAccountUseCase,
   GetAccountsUseCase,
-  type GetAccountsFilters,
 } from "../../application/useCases/account";
 
 const accountRepo = new AccountRepository(db);
@@ -90,19 +89,9 @@ export const getAccounts = async (req: Request, res: Response) => {
     const { ledgerId } = req.query;
     const offset = (page - 1) * limit;
 
-    const filters: GetAccountsFilters = {};
-    
-    if (ledgerId) {
-      // Validate that ledgerId is a valid UUID if provided
-      if (typeof ledgerId === 'string' && ledgerId.length > 0) {
-        filters.ledgerId = ledgerId;
-      }
-    }
-
     const useCase = new GetAccountsUseCase(accountRepo);
-    const accounts = await useCase.execute(filters);
+    const accounts = await useCase.execute(ledgerId as string);
 
-    // Apply pagination to the results
     const paginatedAccounts = accounts.slice(offset, offset + limit);
     const total = accounts.length;
 

--- a/apps/ledger/src/presentation/handlers/accountHandler.ts
+++ b/apps/ledger/src/presentation/handlers/accountHandler.ts
@@ -15,6 +15,7 @@ import {
   CreateAccountUseCase,
   GetAccountUseCase,
   GetAccountsUseCase,
+  type GetAccountsFilters,
 } from "../../application/useCases/account";
 
 const accountRepo = new AccountRepository(db);
@@ -86,10 +87,20 @@ export const getAccount = async (req: Request, res: Response) => {
 export const getAccounts = async (req: Request, res: Response) => {
   try {
     const { page = 1, limit = 10 } = parsePaginationParams(req.query);
+    const { accountId } = req.query;
     const offset = (page - 1) * limit;
 
+    const filters: GetAccountsFilters = {};
+    
+    if (accountId) {
+      // Validate that accountId is a valid UUID if provided
+      if (typeof accountId === 'string' && accountId.length > 0) {
+        filters.accountId = accountId;
+      }
+    }
+
     const useCase = new GetAccountsUseCase(accountRepo);
-    const accounts = await useCase.execute();
+    const accounts = await useCase.execute(filters);
 
     // Apply pagination to the results
     const paginatedAccounts = accounts.slice(offset, offset + limit);


### PR DESCRIPTION
Enable filtering accounts by `ledgerId` in the `getAccounts` endpoint to retrieve all accounts belonging to a specific ledger.